### PR TITLE
tell buildbot to build_ext before running tests

### DIFF
--- a/Makefile.buildbot
+++ b/Makefile.buildbot
@@ -1,0 +1,3 @@
+test:
+	python setup.py build_ext --inplace
+	nosetests


### PR DESCRIPTION
To avoid ImportError: No module named trees_cython
