### PR TITLE
very minor changes to allow import to python 3

### DIFF
--- a/pydepta/__init__.py
+++ b/pydepta/__init__.py
@@ -1,2 +1,3 @@
-from depta import Depta
-from mdr import Region, region_to_dict, dict_to_region
+from .depta import Depta
+from .mdr import Region, region_to_dict, dict_to_region
+

--- a/pydepta/depta.py
+++ b/pydepta/depta.py
@@ -162,3 +162,4 @@ class Depta(object):
     def _region_to_htmlpage(self, region):
         seed_body = tostring(region.parent[region.start], encoding=unicode, method='html')
         return HtmlPage(body=seed_body)
+

--- a/pydepta/htmls.py
+++ b/pydepta/htmls.py
@@ -11,3 +11,4 @@ class DomTreeBuilder(object):
     def build(self):
         parser = etree.HTMLParser(encoding='utf-8')
         return etree.fromstring(self.html, parser)
+

--- a/pydepta/mdr.py
+++ b/pydepta/mdr.py
@@ -417,10 +417,10 @@ class MiningDataField(object):
         # handle text
         if e is not None:
             if seed.text and seed.text.strip():
-                r.append(Field(self._get_text(e.text), ''))
+                r.append(Field(self._get_text(e.text), e))
         else:
             if seed.text and seed.text.strip():
-                r.append(Field(u'', ''))
+                r.append(Field(u'', etree.Element('empty')))
 
         # handle children
         for child in seed:
@@ -429,10 +429,10 @@ class MiningDataField(object):
         # handle tail
         if e is not None:
             if seed.tail and seed.tail.strip():
-                r.append(Field(self._get_text(e.tail) or u'', ''))
+                r.append(Field(self._get_text(e.tail) or u'', e))
         else:
             if seed.tail and seed.tail.strip():
-                r.append(Field(u'', ''))
+                r.append(Field(u'', etree.Element('empty')))
 
         return r
 

--- a/pydepta/mdr.py
+++ b/pydepta/mdr.py
@@ -196,7 +196,13 @@ class MiningDataRegion(object):
                 flag = True
                 for j in xrange(start + i, len(root) - k, k):
                     pair = GeneralizedNode(root[j], k), GeneralizedNode(root[j + k], k)
-                    score = scores.get(pair)
+                    # Note Johannes: I was getting "Unorderable None >= float"
+                    #   in python 2.x "None >= thresh" yields False, while
+                    #   in python 3.x it's illegal
+                    #   https://stackoverflow.com/questions/7383782/
+                    #   technically in py2 "None" evaluates to something less
+                    #       than 0
+                    score = scores.get(pair, 0)
                     if score >= threshold:
                         if flag:
                             cur_region.k = k
@@ -436,3 +442,4 @@ class MiningDataField(object):
                 return text.decode('utf8', 'ignore')
             return text
         return u''
+

--- a/pydepta/trees.py
+++ b/pydepta/trees.py
@@ -472,3 +472,4 @@ class PartialTreeAligner(object):
         get the position of the element within the parent.
         """
         return element.getparent().index(element)
+


### PR DESCRIPTION
- added newlines to end of all files for past.autotranslate / lib2to3
- added default value (0) for score lookup, since py3 doesn't allow `None >= threshold`
- these changes allow importing pydepta from python 3 using "past.autotranslate"